### PR TITLE
Modernize login page with theme support

### DIFF
--- a/prototype/pages/css/common-mo.css
+++ b/prototype/pages/css/common-mo.css
@@ -1,0 +1,141 @@
+/* ========== Base Reset & Typography ========== */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body, html {
+  font-family: Arial, sans-serif;
+  color: var(--text-color);
+  background-color: var(--bg-default);
+  height: 100%;
+}
+
+/* ========== Legacy-Compatible Body Layout ========== */
+body.loginBackground {
+  background-color: var(--bg-default); /* fallback default */
+}
+
+a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
+}
+
+/* ========== Header & Branding ========== */
+.login-header {
+  background-color: var(--header-bg);
+  padding: 1rem;
+  text-align: center;
+}
+.aspen-logo {
+  max-width: 240px;
+  height: auto;
+}
+
+/* ========== Main Form Layout ========== */
+.login-main {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+}
+
+.logonDetailContainer {
+  background-color: var(--bg-form);
+  border-radius: 6px;
+  padding: 2rem;
+  box-shadow: 0 0 10px rgba(0,0,0,0.1);
+  max-width: 400px;
+  width: 100%;
+}
+
+.login-title {
+  font-size: 1.4rem;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+/* ========== Inputs & Buttons ========== */
+.logonInput {
+  width: 100%;
+  padding: 0.75rem;
+  margin-bottom: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+.button {
+  background-color: var(--color-primary);
+  color: white;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 4px;
+  font-size: 1rem;
+  cursor: pointer;
+  width: 100%;
+  text-align: center;
+}
+.button:hover {
+  background-color: var(--color-primary-dark);
+}
+
+.button-text {
+  font-weight: bold;
+}
+
+/* ========== Links Section ========== */
+.login-links {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+.login-links a {
+  color: var(--color-primary);
+}
+
+/* ========== Footer ========== */
+.login-footer {
+  background-color: var(--footer-bg);
+  padding: 0.75rem 1.5rem;
+  font-size: 0.75rem;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  color: white;
+  gap: 0.5rem;
+}
+.login-footer a {
+  color: white;
+  margin-left: 0.5rem;
+}
+.login-footer a:first-child {
+  margin-left: 0;
+}
+
+/* ========== Responsive Layout ========== */
+@media (max-width: 480px) {
+  .logonDetailContainer {
+    padding: 1.5rem;
+  }
+
+  .login-links {
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: flex-start;
+  }
+
+  .button {
+    font-size: 0.95rem;
+  }
+
+  .login-footer {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+}

--- a/prototype/pages/css/themes.css
+++ b/prototype/pages/css/themes.css
@@ -1,0 +1,31 @@
+:root {
+  --bg-default: #f9f9f9;
+  --bg-form: #ffffff;
+  --text-color: #333333;
+  --color-primary: #2673c1;
+  --color-primary-dark: #1d5fa3;
+  --footer-bg: rgba(36, 92, 162, 0.9);
+  --header-bg: rgba(38, 93, 161, 0.91);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-default: #121212;
+    --bg-form: #1e1e1e;
+    --text-color: #f0f0f0;
+    --color-primary: #4c9aff;
+    --color-primary-dark: #3778d8;
+    --footer-bg: rgba(24, 50, 100, 0.9);
+    --header-bg: rgba(26, 56, 110, 0.91);
+  }
+}
+
+[data-theme="dark"] {
+  --bg-default: #121212;
+  --bg-form: #1e1e1e;
+  --text-color: #f0f0f0;
+  --color-primary: #4c9aff;
+  --color-primary-dark: #3778d8;
+  --footer-bg: rgba(24, 50, 100, 0.9);
+  --header-bg: rgba(26, 56, 110, 0.91);
+}

--- a/prototype/pages/index.html
+++ b/prototype/pages/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
@@ -9,8 +9,9 @@
   <!-- Legacy styling support -->
   <link rel="stylesheet" href="css/common-mo.css">
 
-  <!-- Custom modern stylesheet -->
-  <link rel="stylesheet" href="style.css">
+  <!-- Theme variables and dark mode -->
+  <link rel="stylesheet" href="css/themes.css">
+  <!-- Inline color styles removed; see themes.css for variables -->
 
   <!-- Favicon -->
   <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
@@ -21,6 +22,8 @@
     <div class="logo-wrapper">
       <img src="images/follett-aspen-logo.png" alt="Follett Aspen Logo" class="aspen-logo">
     </div>
+    <!-- Theme toggle for bonus -->
+    <button type="button" id="themeToggle" class="button" aria-label="Toggle color scheme">Toggle Theme</button>
   </header>
 
   <main class="login-main">
@@ -71,6 +74,15 @@
       <a href="http://www.follettlearning.com/webapp/wcs/stores/servlet/en/fssmarketingstore/terms-of-use" target="_blank">Terms of Use</a>
     </div>
   </footer>
+
+  <!-- Theme toggle script -->
+  <script>
+    const toggleBtn = document.getElementById('themeToggle');
+    toggleBtn.addEventListener('click', () => {
+      const current = document.documentElement.dataset.theme;
+      document.documentElement.dataset.theme = current === 'dark' ? 'light' : 'dark';
+    });
+  </script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add CSS variable-based theme system with dark mode
- update login CSS to use variables and grid-based footer
- copy legacy stylesheet for prototype
- enhance `index.html` with theme toggle and link to new theme file

## Testing
- `tidy -errors prototype/pages/index.html` *(produces 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688690ea2184832590142462797f4a2a