### PR TITLE
Add create account placeholder and improve login styles

### DIFF
--- a/prototype/pages/create-account.html
+++ b/prototype/pages/create-account.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Aspen: Create Account</title>
+  <link rel="stylesheet" href="../styles/css/common-mo.css">
+  <link rel="stylesheet" href="../styles/css/themes.css">
+</head>
+<body class="loginBackground">
+  <noscript>
+    <div class="noscript-warning">JavaScript is required to use Aspen. Please enable JavaScript in your browser.</div>
+  </noscript>
+  <header class="login-header">
+    <div class="logo-wrapper">
+      <img src="images/follett-aspen-logo.png" alt="Follett Aspen Logo" class="aspen-logo">
+    </div>
+  </header>
+  <main class="login-main">
+    <div class="logonDetailContainer">
+      <h2 class="login-title">Create Account</h2>
+      <p>This page is under construction.</p>
+      <a href="index.html">Back to Login</a>
+    </div>
+  </main>
+</body>
+</html>

--- a/prototype/pages/index.html
+++ b/prototype/pages/index.html
@@ -18,6 +18,10 @@
 </head>
 <body class="loginBackground">
 
+  <noscript>
+    <div class="noscript-warning">JavaScript is required to use Aspen. Please enable JavaScript in your browser.</div>
+  </noscript>
+
   <header class="login-header">
     <div class="logo-wrapper">
       <img src="images/follett-aspen-logo.png" alt="Follett Aspen Logo" class="aspen-logo">
@@ -44,9 +48,11 @@
 
       <label for="username">Login ID</label>
       <input type="text" name="username" id="username" class="logonInput" required>
+      <span class="error-message" id="usernameError" style="display:none;">Login ID required</span>
 
       <label for="password">Password</label>
       <input type="password" name="password" id="password" class="logonInput" required>
+      <span class="error-message" id="passwordError" style="display:none;">Password required</span>
 
       <label for="languageSelect">Language</label>
       <select name="language" id="languageSelect" class="logonSelect">
@@ -58,6 +64,7 @@
         <a href="javascript:EmbeddedPopup.popupManager.open('loginHelp.do?', 420, 320, 100)">Login Assistance</a>
         <a href="javascript:EmbeddedPopup.popupManager.open('passwordRecovery.do?isSecondary=false&amp;deploymentId=aspen', 400, 400, 100)">Parent Portal Password Reset</a>
         <a href="javascript:EmbeddedPopup.popupManager.open('passwordRecovery.do?isSecondary=false&amp;deploymentId=aspen', 400, 400, 100)">Forgot Password?</a>
+        <a href="create-account.html" class="disabled" aria-disabled="true">Create Account</a>
       </div>
 
       <button type="submit" class="button" id="logonButton">

--- a/prototype/pages/reset-password.html
+++ b/prototype/pages/reset-password.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Aspen: Reset Password</title>
+  <link rel="stylesheet" href="../styles/css/common-mo.css">
+  <link rel="stylesheet" href="../styles/css/themes.css">
+</head>
+<body class="loginBackground">
+  <noscript>
+    <div class="noscript-warning">JavaScript is required to use Aspen. Please enable JavaScript in your browser.</div>
+  </noscript>
+  <header class="login-header">
+    <div class="logo-wrapper">
+      <img src="images/follett-aspen-logo.png" alt="Follett Aspen Logo" class="aspen-logo">
+    </div>
+  </header>
+  <main class="login-main">
+    <div class="logonDetailContainer">
+      <h2 class="login-title">Reset Password</h2>
+      <p>This page is under construction.</p>
+      <a href="index.html">Back to Login</a>
+    </div>
+  </main>
+</body>
+</html>

--- a/prototype/styles/css/common-mo.css
+++ b/prototype/styles/css/common-mo.css
@@ -79,6 +79,28 @@ a:hover {
   background-color: var(--bg-form);
 }
 
+.logonInput:focus,
+.logonSelect:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.button:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.input-error {
+  border-color: #e53935;
+}
+
+.error-message {
+  color: #e53935;
+  font-size: 0.8rem;
+  margin-top: -0.5rem;
+  margin-bottom: 0.5rem;
+}
+
 .button {
   background-color: var(--color-primary);
   color: white;
@@ -107,6 +129,18 @@ a:hover {
 }
 .login-links a {
   color: var(--color-primary);
+}
+
+.disabled {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+.noscript-warning {
+  background-color: #ffdddd;
+  color: #333;
+  padding: 1rem;
+  text-align: center;
 }
 
 /* ========== Footer ========== */


### PR DESCRIPTION
## Summary
- refine login page for better focus and error states
- add noscript warning on login page
- link to new create account placeholder
- add reset-password and create-account placeholder pages
- support disabled links and noscript message in CSS

## Testing
- `apt-get update` *(fails: Invalid response from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6886c75471e0832588fcd0b5e04472d9