### PR TITLE
Add list and detail templates

### DIFF
--- a/prototype/pages/detail.html
+++ b/prototype/pages/detail.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Detail View</title>
+
+  <link rel="stylesheet" href="../styles/common-mo.css">
+  <link rel="stylesheet" href="../styles/layout.css">
+  <link rel="stylesheet" href="../styles/utils.css">
+  <link rel="stylesheet" href="../styles/components.css">
+  <link rel="stylesheet" href="../styles/forms.css">
+  <link rel="stylesheet" href="../styles/themes.css">
+</head>
+<body>
+  <div class="layout-wrapper">
+    <nav class="top-nav">
+      <div>Chicago Public Schools</div>
+      <div>User: Jane Admin</div>
+    </nav>
+
+    <div class="layout-container">
+      <aside class="sidebar">
+        <nav class="sidebar-nav">
+          <ul>
+            <li><a href="#">Details</a></li>
+            <li><a href="#">Visits</a></li>
+            <li><a href="#">Immunizations</a></li>
+          </ul>
+        </nav>
+      </aside>
+
+      <main class="main-panel">
+        <div role="tablist" class="mb-2">
+          <button role="tab" aria-selected="true">General</button>
+          <button role="tab">Medical</button>
+        </div>
+
+        <form>
+          <section class="form-section">
+            <h2 class="form-section__title">Student Info</h2>
+            <div>
+              <label for="studentName">Student Name</label>
+              <input id="studentName" type="text" required class="field--error">
+              <span class="error-message text-sm">Required</span>
+
+              <label for="grade">Grade</label>
+              <select id="grade">
+                <option>9</option>
+                <option>10</option>
+              </select>
+
+              <label for="studentId">ID</label>
+              <input id="studentId" type="text" value="A123" readonly class="field--readonly">
+            </div>
+          </section>
+
+          <section class="form-section">
+            <h2 class="form-section__title">Health</h2>
+            <div>
+              <label for="notes">Notes</label>
+              <textarea id="notes" rows="4"></textarea>
+            </div>
+          </section>
+
+          <div class="form-actions form-actions--sticky">
+            <button type="submit" class="button">Save</button>
+            <button type="button" class="button">Cancel</button>
+          </div>
+        </form>
+      </main>
+    </div>
+  </div>
+
+  <script type="module" src="../scripts/components.js"></script>
+</body>
+</html>

--- a/prototype/pages/list.html
+++ b/prototype/pages/list.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>List View</title>
+
+  <link rel="stylesheet" href="../styles/common-mo.css">
+  <link rel="stylesheet" href="../styles/layout.css">
+  <link rel="stylesheet" href="../styles/utils.css">
+  <link rel="stylesheet" href="../styles/components.css">
+  <link rel="stylesheet" href="../styles/table.css">
+  <link rel="stylesheet" href="../styles/themes.css">
+</head>
+<body>
+  <div class="layout-wrapper">
+    <nav class="top-nav">
+      <div>Chicago Public Schools</div>
+      <div>User: Jane Admin</div>
+    </nav>
+
+    <div class="layout-container">
+      <aside class="sidebar">
+        <p>Sidebar navigation</p>
+      </aside>
+
+      <main class="main-panel">
+        <div class="button-menu mb-2">
+          <button type="button">Options</button>
+          <button type="button">Reports</button>
+          <button type="button">Help</button>
+        </div>
+
+        <div class="find-bar">
+          <div class="find-bar__search">
+            <input type="text" placeholder="Search records" aria-label="Search records">
+          </div>
+          <div class="find-bar__filters">
+            <button type="button">Filter</button>
+          </div>
+          <div class="find-bar__bulk-actions text-sm ml-auto">0 of N selected</div>
+        </div>
+
+        <div class="table-wrapper">
+          <table class="table table--comfortable">
+            <thead>
+              <tr>
+                <th class="table__cell--sticky"><input type="checkbox" aria-label="Select all rows"></th>
+                <th class="table__cell--sticky">Student</th>
+                <th class="table__cell--sticky">Status</th>
+                <th class="table__cell--sticky">Date</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><input type="checkbox" aria-label="Select row"></td>
+                <td>John Doe</td>
+                <td><span class="status-pill status-pill--ok">OK</span></td>
+                <td>05/01/2025</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" aria-label="Select row"></td>
+                <td>Jane Smith</td>
+                <td><span class="status-pill status-pill--warn">Missing</span></td>
+                <td>05/03/2025</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" aria-label="Select row"></td>
+                <td>Max Lee</td>
+                <td><span class="status-pill status-pill--na">N/A</span></td>
+                <td>05/04/2025</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="pagination mt-2">Page 1 of 4</div>
+      </main>
+    </div>
+  </div>
+
+  <script type="module" src="../scripts/components.js"></script>
+</body>
+</html>

--- a/prototype/scripts/components.js
+++ b/prototype/scripts/components.js
@@ -4,3 +4,21 @@
 export function initComponents() {
   console.log('components will initialize here');
 }
+
+export function initTabs() {
+  const tablists = document.querySelectorAll('[role="tablist"]');
+  tablists.forEach(list => {
+    const tabs = list.querySelectorAll('[role="tab"]');
+    tabs.forEach(tab => {
+      tab.addEventListener('click', () => {
+        tabs.forEach(t => t.setAttribute('aria-selected', 'false'));
+        tab.setAttribute('aria-selected', 'true');
+      });
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initComponents();
+  initTabs();
+});

--- a/prototype/styles/forms.css
+++ b/prototype/styles/forms.css
@@ -1,0 +1,60 @@
+/* Form layout styles for detail pages */
+.form-section {
+  margin-bottom: 2rem;
+}
+
+.form-section__title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.field--error {
+  border-color: #c0392b;
+}
+
+.field--readonly {
+  background-color: #eee;
+  color: #555;
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.form-actions--sticky {
+  position: sticky;
+  bottom: 0;
+  background-color: var(--bg-form);
+  padding: 0.75rem;
+  border-top: 1px solid rgba(0,0,0,0.1);
+}
+
+[data-theme="dark"] input,
+[data-theme="dark"] select,
+[data-theme="dark"] textarea {
+  background-color: #1e1e1e;
+  border-color: #555;
+  color: var(--text-color);
+}
+
+[data-theme="dark"] .field--readonly {
+  background-color: #2a2a2a;
+  color: #aaa;
+}
+
+[data-theme="dark"] .form-actions--sticky {
+  border-color: rgba(255,255,255,0.1);
+}

--- a/prototype/styles/table.css
+++ b/prototype/styles/table.css
@@ -1,0 +1,69 @@
+/* Responsive table styles for list screens */
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  padding: 0.5rem;
+  border-bottom: 1px solid rgba(0,0,0,0.1);
+  text-align: left;
+}
+
+.table--dense th,
+.table--dense td {
+  padding: 0.25rem 0.5rem;
+}
+
+.table--comfortable th,
+.table--comfortable td {
+  padding: 0.75rem 1rem;
+}
+
+.table__cell--sticky {
+  position: sticky;
+  top: 0;
+  background-color: var(--bg-form);
+  z-index: 1;
+}
+
+.table tbody tr:nth-child(even) {
+  background-color: rgba(0,0,0,0.03);
+}
+
+.table tbody tr:hover {
+  background-color: rgba(38,115,193,0.1);
+}
+
+.table td:focus-within {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+}
+
+.table__row--selected {
+  background-color: rgba(38,115,193,0.15);
+}
+
+.table-wrapper {
+  width: 100%;
+}
+
+@media (max-width: 767px) {
+  .table-wrapper {
+    overflow-x: auto;
+  }
+}
+
+[data-theme="dark"] .table th,
+[data-theme="dark"] .table td {
+  border-color: rgba(255,255,255,0.1);
+}
+
+[data-theme="dark"] .table tbody tr:nth-child(even) {
+  background-color: rgba(255,255,255,0.05);
+}
+
+[data-theme="dark"] .table__cell--sticky {
+  background-color: var(--bg-form);
+}

--- a/prototype/styles/themes.css
+++ b/prototype/styles/themes.css
@@ -6,6 +6,9 @@
   --color-primary-dark: #1d5fa3;
   --footer-bg: rgba(36, 92, 162, 0.9);
   --header-bg: rgba(38, 93, 161, 0.91);
+  --status-ok: #1b8753;
+  --status-warn: #c26100;
+  --status-na: #6b6b6b;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -17,6 +20,9 @@
     --color-primary-dark: #3778d8;
     --footer-bg: rgba(24, 50, 100, 0.9);
     --header-bg: rgba(26, 56, 110, 0.91);
+    --status-ok: #2e9e64;
+    --status-warn: #e09533;
+    --status-na: #8a8a8a;
   }
 }
 
@@ -28,4 +34,7 @@
   --color-primary-dark: #3778d8;
   --footer-bg: rgba(24, 50, 100, 0.9);
   --header-bg: rgba(26, 56, 110, 0.91);
+  --status-ok: #2e9e64;
+  --status-warn: #e09533;
+  --status-na: #8a8a8a;
 }


### PR DESCRIPTION
## Summary
- build shared table styles
- add list.html using table layout
- build form layout styles
- create detail.html for student record screens
- expose basic tab initializer
- extend theme variables for status pills

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68876fde8c688325afc47d20e864bb65