### PR TITLE
Add reposMenuLeft CSS conflict details

### DIFF
--- a/research/analysis/css_conflicts.md
+++ b/research/analysis/css_conflicts.md
@@ -7,8 +7,15 @@ The following overlapping class definitions were detected in `research/captures/
 - `.listCellLastSelectionHighlight` — defined in **common-mo.css** and **health.css**.
 - `.ui-accordion-header` — present in **common-mo.css** and **jquery-ui-1.12.1.min.css**.
 - `.disabled` — rules exist in **common-header.css** and **common-mo.css**.
+- `.reposMenuLeft` — defined in **common-header.css** and **common-mo.css**. No captured pages currently use this class.
 
 These overlaps may cause inconsistent styling when legacy sheets are combined.
+
+### Usage in captured pages
+
+- `.reset_style_h1_top` — appears on **Aspen: Details**, **Aspen: Student List**, **Aspen: Enrollment**, and **Aspen: Immunizations**.
+- `.repositoryListClass` — referenced in inline styles of **Aspen: Pages** only.
+- `.reposMenuLeft`, `.listCellLastSelectionHighlight`, `.ui-accordion-header`, and `.disabled` — not present in the HTML samples.
 
 ## July 2025 testing
 Loaded legacy student table fragment inside the new layout. Observed that `.button` and `.widget` share styles with different margins. Legacy `.button` required higher specificity; mapped with `legacy-map.css`.


### PR DESCRIPTION
## Summary
- parse `css_captures` and document new duplicate `.reposMenuLeft`
- note which pages reference captured CSS classes

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build:manifest`

------
https://chatgpt.com/codex/tasks/task_e_6887fc74e0b48325905bb4973fae8a6c