### PR TITLE
Implement sticky actions footer and modal component

### DIFF
--- a/prototype/scripts/components.js
+++ b/prototype/scripts/components.js
@@ -18,7 +18,37 @@ export function initTabs() {
   });
 }
 
+export function initStickyActions() {
+  const bars = document.querySelectorAll('.form-actions--sticky');
+  const update = bar => {
+    const floating = window.scrollY + window.innerHeight >= bar.offsetTop + bar.offsetHeight;
+    bar.classList.toggle('form-actions--floating', floating);
+  };
+  bars.forEach(bar => {
+    update(bar);
+    window.addEventListener('scroll', () => update(bar));
+    window.addEventListener('resize', () => update(bar));
+  });
+}
+
+export function initModals() {
+  document.querySelectorAll('[data-modal-open]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const target = document.getElementById(btn.getAttribute('data-modal-open'));
+      if (target) target.classList.add('modal--open');
+    });
+  });
+  document.querySelectorAll('[data-modal-close]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const modal = btn.closest('.modal');
+      if (modal) modal.classList.remove('modal--open');
+    });
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   initComponents();
   initTabs();
+  initStickyActions();
+  initModals();
 });

--- a/prototype/styles/components.css
+++ b/prototype/styles/components.css
@@ -135,3 +135,54 @@
     flex-basis: 33.333%;
   }
 }
+/* ========== Form Actions Footer ========== */
+.form-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.form-actions--sticky {
+  position: sticky;
+  bottom: 0;
+  background-color: var(--bg-form);
+  padding: 0.75rem;
+  border-top: 1px solid rgba(0,0,0,0.1);
+}
+
+.form-actions--floating {
+  box-shadow: 0 -2px 4px rgba(0,0,0,0.08);
+}
+
+[data-theme="dark"] .form-actions--sticky {
+  border-color: rgba(255,255,255,0.1);
+}
+
+/* ========== Modal Dialog ========== */
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0,0,0,0.5);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s ease-in-out;
+}
+
+.modal--open {
+  opacity: 1;
+  visibility: visible;
+}
+
+.modal__dialog {
+  background-color: var(--bg-form);
+  padding: 1rem;
+  border-radius: 4px;
+  min-width: 300px;
+  max-width: 90%;
+}
+
+[data-theme="dark"] .modal__dialog {
+  box-shadow: 0 1px 3px rgba(0,0,0,0.5);
+}

--- a/prototype/styles/table.css
+++ b/prototype/styles/table.css
@@ -44,6 +44,16 @@
 .table__row--selected {
   background-color: rgba(38,115,193,0.15);
 }
+.table__row--dense th,
+.table__row--dense td {
+  padding: 0.25rem 0.5rem;
+}
+
+.table__row--comfortable th,
+.table__row--comfortable td {
+  padding: 0.75rem 1rem;
+}
+
 
 .table-wrapper {
   width: 100%;


### PR DESCRIPTION
## Summary
- add sticky form footer and floating style classes
- add minimal modal dialog styling and dark theme adjustments
- implement JS to activate sticky form actions and open/close modals
- support dense and comfortable modifiers at the row level in tables

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6887fdd41574832598dfdc0498831d81