### PR TITLE
Add menu highlight mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Use its contents to:
 
 For example:
 - .listCellLastSelectionHighlight → mapped to --legacy-highlight
+- c1Color / c1Background / c1Border → mapped to --legacy-c1
+- c2Color / c2Background / c2Border (+ left/top) → mapped to --legacy-c2
+- c3Color / c3Background / c3Border → mapped to --legacy-c3
+- .menuItemHighlight → mapped to --legacy-highlight
 - .repositoryListClass conflicts → noted for resolution in components.css or utils.css
 
 ## Dummy Data Policy

--- a/prototype/styles/legacy-map.css
+++ b/prototype/styles/legacy-map.css
@@ -4,6 +4,7 @@
   --legacy-c2: #AD4D5F;
   --legacy-c3: #5C0000;
   --legacy-highlight: #EABBC4;
+  --legacy-menu-highlight: var(--legacy-highlight);
 }
 
 .c1Background { background-color: var(--legacy-c1) !important; }
@@ -19,5 +20,7 @@
 .c3Background { background-color: var(--legacy-c3); }
 .c3Color { color: var(--legacy-c3); }
 .c3Border { border-color: var(--legacy-c3); }
+
+.menuItemHighlight { background-color: var(--legacy-menu-highlight); }
 
 .listCellLastSelectionHighlight { background-color: var(--legacy-highlight) !important; }


### PR DESCRIPTION
## Summary
- map menuItemHighlight class to new --legacy-menu-highlight variable
- note color mapping details in Compatibility section of README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6887fff78d148325b189585af731bb8d