### PR TITLE
Document DOM structures and update component list

### DIFF
--- a/docs/maps/home.dom.md
+++ b/docs/maps/home.dom.md
@@ -1,0 +1,23 @@
+# DOM Map: home.html
+
+- body.bodyBackground
+  - form[name="authenticatedActionForm"]
+    - input[type=hidden] (token, userEvent, userParam, etc.)
+  - div#loadingCover.loadingCover
+  - div#layoutHeader.layoutHeader
+    - div#header
+      - table (title bar and tabs)
+  - div#main
+    - table
+      - td#pageMenuContainer.pageMenuContainer
+      - td#widgetsContainer.widgetsContainer
+  - div#myResourcesPanel.myResources.draggableByHandle
+    - div.draggableHandle.c2Background
+    - div#myResourcesTreePanel
+      - div#myResourcesContent
+  - div#messageWindow
+
+## 🧩 Component Candidates
+- PageMenu
+- WidgetPanel
+- ResourceDrawer

--- a/docs/maps/student-details.dom.md
+++ b/docs/maps/student-details.dom.md
@@ -1,0 +1,40 @@
+# DOM Map: student_details.html
+
+- body.bodyBackground
+  - div#overlay
+  - div#spellingMenu
+  - form[name="personAddressDetailForm"]
+    - input[type=hidden] (token, userEvent, userParam, etc.)
+    - table#layoutHeader.layoutHeader
+      - div#topTitleBar
+        - div#contextMenu
+        - div#contextMenuPane
+        - div#userPreferenceMenu
+        - div#userPreferenceMenuPane
+      - div#c2colorRef
+      - div#topMenuBar
+        - div#topMenuBarLeft
+        - div#actualTopMenuBar
+        - div#topMenuBarRight
+    - div#contentArea.contentPad
+      - table.breadcrumbs
+      - table.nav buttons
+      - div#searchStringDiv.searchStringDiv
+      - table.layoutVerticalTabsContainer
+        - div#layoutVerticalTabs
+          - tr.verticalTabSelected
+          - tr.verticalTab (Visits, Immunizations, Conditions, etc.)
+      - td.contentContainer
+        - table.optionsBar
+          - div#maximizeMenuButton
+          - div#options + div#optionsPane
+          - div#reportsMenu + div#reportsMenuPane
+          - div#helpMenu + div#helpMenuPane
+        - div#collapsibleDiv0.detailContainer
+        - div#collapsibleDiv1
+        - div#collapsibleDiv2.detailContainer
+        - div#collapsibleDiv3.detailContainer
+  - div#messageWindow
+
+## 🧩 Component Candidates
+- detail-form

--- a/docs/maps/student.dom.md
+++ b/docs/maps/student.dom.md
@@ -1,0 +1,26 @@
+# DOM Map: student.html
+
+- body.bodyBackground
+  - div#overlay
+  - div#spellingMenu
+  - form[name="contextListForm"]
+    - input[type=hidden] (token, userEvent, userParam, etc.)
+    - table.layoutHeader
+      - div#topTitleBar
+        - div#contextMenu
+        - div#contextMenuPane
+        - div#userPreferenceMenu
+        - div#userPreferenceMenuPane
+      - div#c2colorRef
+      - div#topMenuBar
+        - div#topMenuBarLeft
+        - div#actualTopMenuBar
+        - div#topMenuBarRight
+    - table#contextTabs (nav tabs)
+    - div#contentArea.contentPad
+      - table.optionsBar
+      - table.grid (student list)
+  - div#messageWindow
+
+## 🧩 Component Candidates
+- student-tabs

--- a/research/analysis/components.md
+++ b/research/analysis/components.md
@@ -6,11 +6,17 @@
 - Search bar (`find-bar`)
 - Status pills
 - Two-column grid (`main-grid`)
-
-## Planned
 - Sticky form actions footer
 - Dense/comfortable table variants
-- Modal dialogs (needs JS)
+- Modal dialogs
+
+## Planned
+- Login form (`login-form`)
+- Student tab navigation (`student-tabs`)
+- Detail record form (`detail-form`)
+- Health exam form (`exam-form`)
+- Immunization table (`imms-table`)
+- Membership table (`membership-table`)
 
 ## Utility Classes
 - Adopted margin and padding helpers from `utils.css`


### PR DESCRIPTION
## Summary
- mark sticky footer, table density modifiers and modals as implemented
- list new planned components from capture analysis
- add DOM outlines for `home.html`, `student.html`, and `student_details.html`

## Testing
- `npm run build:manifest`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68880783df208325a021fbd13470d2e8