### PR TITLE
Add login and exam component stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ For example:
 - c2Color / c2Background / c2Border (+ left/top) → mapped to --legacy-c2
 - c3Color / c3Background / c3Border → mapped to --legacy-c3
 - .menuItemHighlight → mapped to --legacy-highlight
+- Navigation bar colors from `common-header.css` →
+  `--legacy-dashboard`, `--legacy-myinfo`, `--legacy-student`,
+  `--legacy-attendance`, `--legacy-gradebook`, `--legacy-planner`,
+  `--legacy-quest`, `--legacy-pd`
 - .repositoryListClass conflicts → noted for resolution in components.css or utils.css
 
 ## Dummy Data Policy

--- a/prototype/pages/exam-form.html
+++ b/prototype/pages/exam-form.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Health Exam Form Component</title>
+  <link rel="stylesheet" href="../styles/common-mo.css">
+  <link rel="stylesheet" href="../styles/forms.css">
+  <link rel="stylesheet" href="../styles/themes.css">
+</head>
+<body>
+  <form class="exam-form">
+    <div class="exam-form__row">
+      <label for="examDate">Exam Date</label>
+      <input type="date" id="examDate" required>
+    </div>
+    <div class="exam-form__row">
+      <label for="examNotes">Notes</label>
+      <textarea id="examNotes" rows="3"></textarea>
+    </div>
+    <div class="form-actions">
+      <button type="submit" class="button">Save</button>
+    </div>
+  </form>
+</body>
+</html>

--- a/prototype/pages/login-form.html
+++ b/prototype/pages/login-form.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Login Form Component</title>
+  <link rel="stylesheet" href="../styles/common-mo.css">
+  <link rel="stylesheet" href="../styles/forms.css">
+  <link rel="stylesheet" href="../styles/themes.css">
+</head>
+<body>
+  <form class="login-form">
+    <div class="login-form__field">
+      <label for="loginUsername">User ID</label>
+      <input type="text" id="loginUsername" required>
+    </div>
+    <div class="login-form__field">
+      <label for="loginPassword">Password</label>
+      <input type="password" id="loginPassword" required>
+    </div>
+    <div class="login-form__actions">
+      <button type="submit" class="button">Log On</button>
+    </div>
+  </form>
+</body>
+</html>

--- a/prototype/styles/forms.css
+++ b/prototype/styles/forms.css
@@ -58,3 +58,45 @@ textarea {
 [data-theme="dark"] .form-actions--sticky {
   border-color: rgba(255,255,255,0.1);
 }
+
+/* ========== Login Form ========== */
+.login-form {
+  max-width: 400px;
+  margin: 2rem auto;
+  background-color: var(--bg-form);
+  padding: 1.5rem;
+  border-radius: 6px;
+  box-shadow: 0 0 10px rgba(0,0,0,0.1);
+}
+
+.login-form__field {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+
+.login-form__actions {
+  text-align: center;
+}
+
+/* ========== Health Exam Form ========== */
+.exam-form {
+  max-width: 600px;
+  margin: 2rem auto;
+}
+
+.exam-form__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.exam-form__row label {
+  flex: 0 0 200px;
+}
+
+.exam-form__row input,
+.exam-form__row textarea {
+  flex: 1 1 200px;
+}

--- a/prototype/styles/legacy-map.css
+++ b/prototype/styles/legacy-map.css
@@ -5,6 +5,14 @@
   --legacy-c3: #5C0000;
   --legacy-highlight: #EABBC4;
   --legacy-menu-highlight: var(--legacy-highlight);
+  --legacy-dashboard: #445;
+  --legacy-myinfo: #cc3300;
+  --legacy-student: #ff6600;
+  --legacy-attendance: #ff9900;
+  --legacy-gradebook: #336600;
+  --legacy-planner: #669900;
+  --legacy-quest: #193366;
+  --legacy-pd: #1966b2;
 }
 
 .c1Background { background-color: var(--legacy-c1) !important; }

--- a/research/analysis/components.md
+++ b/research/analysis/components.md
@@ -9,12 +9,12 @@
 - Sticky form actions footer
 - Dense/comfortable table variants
 - Modal dialogs
+- Login form (`login-form`)
+- Health exam form (`exam-form`)
 
 ## Planned
-- Login form (`login-form`)
 - Student tab navigation (`student-tabs`)
 - Detail record form (`detail-form`)
-- Health exam form (`exam-form`)
 - Immunization table (`imms-table`)
 - Membership table (`membership-table`)
 


### PR DESCRIPTION
## Summary
- stub pages for login-form and exam-form components
- define basic BEM styles in forms.css
- extend legacy-map.css with navigation colors
- document implemented components
- note new legacy variables in README

## Testing
- `npm install`
- `npm run build:manifest`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6888098498508325a3479a62a88644f5