### PR TITLE
Improve login prototype layout

### DIFF
--- a/prototype/pages/index.html
+++ b/prototype/pages/index.html
@@ -17,19 +17,23 @@
   <link rel="shortcut icon" href="../../images/favicon.ico" type="image/x-icon">
 </head>
 <body class="loginBackground">
-  <noscript>
-    <div class="noscript-warning">JavaScript is required to use Aspen. Please enable JavaScript.</div>
-  </noscript>
+  <div class="wrapper">
+    <div class="main-content">
+      <noscript>
+        <div class="noscript-warning">JavaScript is required to use Aspen. Please enable JavaScript.</div>
+      </noscript>
 
-  <header class="login-header">
-    <div class="logo-wrapper">
-      <img src="../../images/new-aspen-logo.png" alt="CPS Aspen Header Logo" class="aspen-logo">
-    </div>
-    <!-- Theme toggle for bonus -->
-    <button type="button" id="themeToggle" class="button" aria-label="Toggle color scheme" aria-pressed="false">Toggle Theme</button>
-  </header>
+      <header class="login-header">
+        <div class="logo-wrapper">
+          <img src="../../images/new-aspen-logo.png" alt="CPS Aspen Header Logo" class="aspen-logo">
+        </div>
+        <!-- Theme toggle for bonus -->
+        <div style="display: flex; justify-content: center;">
+          <button type="button" id="themeToggle" class="theme-toggle" aria-label="Toggle color scheme" aria-pressed="false">Toggle Theme</button>
+        </div>
+      </header>
 
-  <main class="login-main">
+      <main class="login-main">
     <form name="logonForm" method="post" action="/aspen/logon.do" class="logonDetailContainer">
       <!-- Required hidden fields for backend -->
       <input type="hidden" name="org.apache.struts.taglib.html.TOKEN" value="a9592cac982b15f8b17ab4e24995cd91">
@@ -75,16 +79,18 @@
     </form>
   </main>
 
-  <footer class="login-footer">
-    <div class="footer-left">
-      &copy; 2025 Follett School Solutions, LLC. All rights reserved.
-    </div>
-    <div class="footer-right">
-      <a href="http://www.follettlearning.com/" target="_blank">Follett School Solutions</a> |
-      <a href="http://www.follettlearning.com/technology/products/student-information-system" target="_blank">Aspen</a> |
-      <a href="http://www.follettlearning.com/webapp/wcs/stores/servlet/en/fssmarketingstore/terms-of-use" target="_blank">Terms of Use</a>
-    </div>
-  </footer>
+      <footer class="footer login-footer">
+        <div class="footer-left">
+          &copy; 2025 Follett School Solutions, LLC. All rights reserved.
+        </div>
+        <div class="footer-right">
+          <a href="http://www.follettlearning.com/" target="_blank">Follett School Solutions</a> |
+          <a href="http://www.follettlearning.com/technology/products/student-information-system" target="_blank">Aspen</a> |
+          <a href="http://www.follettlearning.com/webapp/wcs/stores/servlet/en/fssmarketingstore/terms-of-use" target="_blank">Terms of Use</a>
+        </div>
+      </footer>
+    </div> <!-- .main-content -->
+  </div> <!-- .wrapper -->
 
   <!-- Theme toggle script -->
   <script>

--- a/prototype/styles/common-mo.css
+++ b/prototype/styles/common-mo.css
@@ -105,15 +105,37 @@ a:hover {
   font-weight: bold;
 }
 
+/* ========== Theme Toggle Button ========== */
+.theme-toggle {
+  display: inline-block;
+  margin: 1rem auto;
+  padding: 0.5rem 1rem;
+  background-color: #4a90e2;
+  border: none;
+  border-radius: 6px;
+  color: white;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+.theme-toggle:hover {
+  background-color: #357ABD;
+}
+
 /* ========== Links Section ========== */
 .login-links {
   display: flex;
-  justify-content: space-between;
-  margin-bottom: 1rem;
-  font-size: 0.9rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1rem;
+  font-size: 0.875rem;
 }
 .login-links a {
-  color: var(--color-primary);
+  color: #4a90e2;
+  text-decoration: none;
+}
+.login-links a:hover {
+  text-decoration: underline;
 }
 .disabled-link {
   pointer-events: none;
@@ -164,9 +186,9 @@ a:hover {
   }
 
   .login-links {
-    flex-direction: column;
-    gap: 0.5rem;
-    align-items: flex-start;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 0.75rem;
   }
 
   .button {
@@ -177,4 +199,20 @@ a:hover {
     grid-template-columns: 1fr;
     text-align: center;
   }
+}
+
+/* ========== Wrapper Layout ========== */
+.wrapper {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+.main-content {
+  flex: 1;
+}
+.footer {
+  background-color: #0f2b5b;
+  color: white;
+  padding: 0.5rem;
+  text-align: center;
 }


### PR DESCRIPTION
## Summary
- wrap login page with `.wrapper` for sticky footer
- center the theme toggle button and apply modern style
- center & restyle login links
- add layout helpers in `common-mo.css`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68883b9244a08325a160aad01d267da7