### PR TITLE
Add dependency check for build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ All sample HTML uses either anonymized data or the developer’s own record. No 
 
 ## Build Instructions
 
-Run the following commands to install dependencies and generate the manifest:
+Run the following commands to install dependencies and generate the manifest.  
+If `npm run build:manifest` fails because `cheerio` is missing, make sure you ran `npm install` first:
 
 ```bash
 npm install

--- a/prototype/scripts/build-manifest.mjs
+++ b/prototype/scripts/build-manifest.mjs
@@ -2,7 +2,13 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-import { load } from "cheerio";
+let load;
+try {
+  ({ load } = await import('cheerio'));
+} catch (err) {
+  console.error('Missing dependency: cheerio. Run "npm install" before running build-manifest.');
+  process.exit(1);
+}
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..', '..');
 const captureDir = path.join(rootDir, 'research', 'captures');


### PR DESCRIPTION
## Summary
- add friendly message if `cheerio` isn't installed
- clarify in README that `npm install` must run first

## Testing
- `npm run build:manifest`

------
https://chatgpt.com/codex/tasks/task_e_6889712497908325baea2c75ad355ad2