### PR TITLE
Apply new color palette across prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ aspen-redesign/
 Project images and logos live in the `images/` folder at the repository root.
 The file `images/aspen-header-logo.png` serves as the Aspen logo in both light and dark themes.
 
+## Color Palette
+
+The prototype uses a human-centered palette to reinforce clarity and support:
+
+| Color                | Hex       | Purpose |
+|----------------------|----------|---------|
+| Soft Teal            | `#73C6B6` | District base accents |
+| Denim Blue           | `#4A90E2` | Primary interface color |
+| Muted Coral Red      | `#F67280` | Health alerts and errors |
+| Warm Cream           | `#FDF6EC` | Default page background |
+| Goldenrod Yellow     | `#F9D342` | Highlights and buttons |
+| Slate Purple         | `#A28DFF` | Alternate accent |
+| Cool Mint            | `#B2F2BB` | Success confirmations |
+
+
 ## Layout & Components
 
 The layout system (`layout.css`, `components.css`) is mobile-first, using a grid and reusable widgets. Theme variables enable light/dark modes and fallback to legacy styles via `legacy-map.css`. Utility classes in `utils.css` provide spacing and flexbox helpers. Interactive widgets are organized under `prototype/scripts/`.

--- a/prototype/styles/common-mo.css
+++ b/prototype/styles/common-mo.css
@@ -110,7 +110,7 @@ a:hover {
   display: inline-block;
   margin: 1rem auto;
   padding: 0.5rem 1rem;
-  background-color: #4a90e2;
+  background-color: var(--color-primary);
   border: none;
   border-radius: 6px;
   color: white;
@@ -118,7 +118,7 @@ a:hover {
   transition: background-color 0.3s;
 }
 .theme-toggle:hover {
-  background-color: #357ABD;
+  background-color: var(--color-primary-dark);
 }
 
 /* ========== Links Section ========== */
@@ -131,7 +131,7 @@ a:hover {
   font-size: 0.875rem;
 }
 .login-links a {
-  color: #4a90e2;
+  color: var(--color-primary);
   text-decoration: none;
 }
 .login-links a:hover {
@@ -143,18 +143,18 @@ a:hover {
 }
 
 .input-error {
-  border-color: #c0392b;
+  border-color: var(--color-health);
 }
 
 .error-message {
-  color: #c0392b;
+  color: var(--color-health);
   font-size: 0.85rem;
   margin-top: -0.5rem;
   margin-bottom: 1rem;
 }
 
 .noscript-warning {
-  background-color: #c0392b;
+  background-color: var(--color-health);
   color: #fff;
   padding: 1rem;
   text-align: center;
@@ -211,7 +211,7 @@ a:hover {
   flex: 1;
 }
 .footer {
-  background-color: #0f2b5b;
+  background-color: var(--footer-bg);
   color: white;
   padding: 0.5rem;
   text-align: center;

--- a/prototype/styles/forms.css
+++ b/prototype/styles/forms.css
@@ -21,7 +21,7 @@ textarea {
 }
 
 .field--error {
-  border-color: #c0392b;
+  border-color: var(--color-health);
 }
 
 .field--readonly {

--- a/prototype/styles/themes.css
+++ b/prototype/styles/themes.css
@@ -1,12 +1,18 @@
 :root {
-  --bg-default: #f9f9f9;
+  --bg-default: #FDF6EC; /* Warm Cream */
   --bg-form: #ffffff;
   --text-color: #333333;
-  --color-primary: #2673c1;
-  --color-primary-dark: #1d5fa3;
-  --footer-bg: rgba(36, 92, 162, 0.9);
-  --header-bg: rgba(38, 93, 161, 0.91);
-  --status-ok: #1b8753;
+  --color-district: #73C6B6;
+  --color-school: #4A90E2;
+  --color-health: #F67280;
+  --color-primary: var(--color-school);
+  --color-primary-dark: #357ABD;
+  --footer-bg: rgba(74, 144, 226, 0.9);
+  --header-bg: rgba(74, 144, 226, 0.91);
+  --accent-yellow: #F9D342;
+  --accent-purple: #A28DFF;
+  --accent-mint: #B2F2BB;
+  --status-ok: var(--accent-mint);
   --status-warn: #c26100;
   --status-na: #6b6b6b;
 }
@@ -16,11 +22,11 @@
     --bg-default: #121212;
     --bg-form: #1e1e1e;
     --text-color: #f0f0f0;
-    --color-primary: #4c9aff;
-    --color-primary-dark: #3778d8;
-    --footer-bg: rgba(24, 50, 100, 0.9);
-    --header-bg: rgba(26, 56, 110, 0.91);
-    --status-ok: #2e9e64;
+    --color-primary: #A28DFF;
+    --color-primary-dark: #8B72EB;
+    --footer-bg: rgba(162, 141, 255, 0.9);
+    --header-bg: rgba(162, 141, 255, 0.91);
+    --status-ok: var(--accent-mint);
     --status-warn: #e09533;
     --status-na: #8a8a8a;
   }
@@ -30,11 +36,11 @@
   --bg-default: #121212;
   --bg-form: #1e1e1e;
   --text-color: #f0f0f0;
-  --color-primary: #4c9aff;
-  --color-primary-dark: #3778d8;
-  --footer-bg: rgba(24, 50, 100, 0.9);
-  --header-bg: rgba(26, 56, 110, 0.91);
-  --status-ok: #2e9e64;
+  --color-primary: #A28DFF;
+  --color-primary-dark: #8B72EB;
+  --footer-bg: rgba(162, 141, 255, 0.9);
+  --header-bg: rgba(162, 141, 255, 0.91);
+  --status-ok: var(--accent-mint);
   --status-warn: #e09533;
   --status-na: #8a8a8a;
 }


### PR DESCRIPTION
## Summary
- document the Human-Centered color palette in `README`
- define palette variables in `themes.css`
- use new variables in `common-mo.css` and `forms.css`
- regenerate `manifest.json`

## Testing
- `npm install`
- `npm run build:manifest`

------
https://chatgpt.com/codex/tasks/task_e_688998f8c35483259b6953faf76e00e9