### PR TITLE
Add shared theme toggle script

### DIFF
--- a/prototype/pages/create-account.html
+++ b/prototype/pages/create-account.html
@@ -14,6 +14,9 @@
     <div class="logo-wrapper">
       <img src="../../images/aspen-header-logo.png" alt="CPS Aspen Header Logo" class="aspen-logo">
     </div>
+    <div style="display: flex; justify-content: center;">
+      <button type="button" id="themeToggle" class="theme-toggle" aria-label="Toggle color scheme" aria-pressed="false">Toggle Theme</button>
+    </div>
   </header>
   <main class="login-main">
     <div class="logonDetailContainer">
@@ -25,5 +28,6 @@
   <footer class="login-footer">
     <div class="footer-left">&copy; 2025 Follett School Solutions, LLC.</div>
   </footer>
+  <script type="module" src="../scripts/components.js"></script>
 </body>
 </html>

--- a/prototype/pages/detail.html
+++ b/prototype/pages/detail.html
@@ -19,6 +19,9 @@
       <div>Chicago Public Schools</div>
       <div>User: Jane Admin</div>
     </nav>
+    <div style="display: flex; justify-content: center; margin: 0.5rem 0;">
+      <button type="button" id="themeToggle" class="theme-toggle" aria-label="Toggle color scheme" aria-pressed="false">Toggle Theme</button>
+    </div>
 
     <div class="layout-container">
       <aside class="sidebar">

--- a/prototype/pages/exam-form.html
+++ b/prototype/pages/exam-form.html
@@ -10,6 +10,9 @@
   <link rel="stylesheet" href="../styles/themes.css">
 </head>
 <body>
+  <div style="display: flex; justify-content: center; margin-bottom: 1rem;">
+    <button type="button" id="themeToggle" class="theme-toggle" aria-label="Toggle color scheme" aria-pressed="false">Toggle Theme</button>
+  </div>
   <form class="exam-form">
     <div class="exam-form__row">
       <label for="examDate">Exam Date</label>
@@ -23,5 +26,6 @@
       <button type="submit" class="button">Save</button>
     </div>
   </form>
+  <script type="module" src="../scripts/components.js"></script>
 </body>
 </html>

--- a/prototype/pages/home.html
+++ b/prototype/pages/home.html
@@ -94,17 +94,6 @@
     </div>
   </div>
 
-  <script>
-    const toggleBtn = document.getElementById('themeToggle');
-    if (toggleBtn) {
-      toggleBtn.addEventListener('click', () => {
-        const current = document.documentElement.dataset.theme;
-        const newTheme = current === 'dark' ? 'light' : 'dark';
-        document.documentElement.dataset.theme = newTheme;
-        toggleBtn.setAttribute('aria-pressed', newTheme === 'dark');
-      });
-    }
-  </script>
   <script type="module" src="../scripts/components.js"></script>
 </body>
 </html>

--- a/prototype/pages/immunizations.html
+++ b/prototype/pages/immunizations.html
@@ -18,6 +18,9 @@
       <div>Chicago Public Schools</div>
       <div>User: Jane Admin</div>
     </nav>
+    <div style="display: flex; justify-content: center; margin: 0.5rem 0;">
+      <button type="button" id="themeToggle" class="theme-toggle" aria-label="Toggle color scheme" aria-pressed="false">Toggle Theme</button>
+    </div>
 
     <div class="layout-container">
       <aside class="sidebar">

--- a/prototype/pages/index.html
+++ b/prototype/pages/index.html
@@ -92,16 +92,7 @@
     </div> <!-- .main-content -->
   </div> <!-- .wrapper -->
 
-  <!-- Theme toggle script -->
-  <script>
-    const toggleBtn = document.getElementById('themeToggle');
-    toggleBtn.addEventListener('click', () => {
-      const current = document.documentElement.dataset.theme;
-      const newTheme = current === 'dark' ? 'light' : 'dark';
-      document.documentElement.dataset.theme = newTheme;
-      toggleBtn.setAttribute('aria-pressed', newTheme === 'dark');
-    });
-  </script>
+  <script type="module" src="../scripts/components.js"></script>
 
 </body>
 </html>

--- a/prototype/pages/list.html
+++ b/prototype/pages/list.html
@@ -19,6 +19,9 @@
       <div>Chicago Public Schools</div>
       <div>User: Jane Admin</div>
     </nav>
+    <div style="display: flex; justify-content: center; margin: 0.5rem 0;">
+      <button type="button" id="themeToggle" class="theme-toggle" aria-label="Toggle color scheme" aria-pressed="false">Toggle Theme</button>
+    </div>
 
     <div class="layout-container">
       <aside class="sidebar">

--- a/prototype/pages/login-form.html
+++ b/prototype/pages/login-form.html
@@ -10,6 +10,9 @@
   <link rel="stylesheet" href="../styles/themes.css">
 </head>
 <body>
+  <div style="display: flex; justify-content: center; margin-bottom: 1rem;">
+    <button type="button" id="themeToggle" class="theme-toggle" aria-label="Toggle color scheme" aria-pressed="false">Toggle Theme</button>
+  </div>
   <form class="login-form">
     <div class="login-form__field">
       <label for="loginUsername">User ID</label>
@@ -23,5 +26,6 @@
       <button type="submit" class="button">Log On</button>
     </div>
   </form>
+  <script type="module" src="../scripts/components.js"></script>
 </body>
 </html>

--- a/prototype/pages/membership.html
+++ b/prototype/pages/membership.html
@@ -18,6 +18,9 @@
       <div>Chicago Public Schools</div>
       <div>User: Jane Admin</div>
     </nav>
+    <div style="display: flex; justify-content: center; margin: 0.5rem 0;">
+      <button type="button" id="themeToggle" class="theme-toggle" aria-label="Toggle color scheme" aria-pressed="false">Toggle Theme</button>
+    </div>
 
     <div class="layout-container">
       <aside class="sidebar">

--- a/prototype/pages/reset-password.html
+++ b/prototype/pages/reset-password.html
@@ -14,6 +14,9 @@
     <div class="logo-wrapper">
       <img src="../../images/aspen-header-logo.png" alt="CPS Aspen Header Logo" class="aspen-logo">
     </div>
+    <div style="display: flex; justify-content: center;">
+      <button type="button" id="themeToggle" class="theme-toggle" aria-label="Toggle color scheme" aria-pressed="false">Toggle Theme</button>
+    </div>
   </header>
   <main class="login-main">
     <div class="logonDetailContainer">
@@ -25,5 +28,6 @@
   <footer class="login-footer">
     <div class="footer-left">&copy; 2025 Follett School Solutions, LLC.</div>
   </footer>
+  <script type="module" src="../scripts/components.js"></script>
 </body>
 </html>

--- a/prototype/scripts/components.js
+++ b/prototype/scripts/components.js
@@ -46,9 +46,29 @@ export function initModals() {
   });
 }
 
+export function initThemeToggle() {
+  const toggleBtn = document.getElementById('themeToggle');
+  if (!toggleBtn) return;
+
+  const setState = theme => {
+    document.documentElement.dataset.theme = theme;
+    toggleBtn.setAttribute('aria-pressed', theme === 'dark');
+  };
+
+  toggleBtn.addEventListener('click', () => {
+    const current = document.documentElement.dataset.theme || 'light';
+    const newTheme = current === 'dark' ? 'light' : 'dark';
+    setState(newTheme);
+  });
+
+  // initialize button state
+  setState(document.documentElement.dataset.theme || 'light');
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   initComponents();
   initTabs();
   initStickyActions();
   initModals();
+  initThemeToggle();
 });


### PR DESCRIPTION
## Summary
- centralize theme toggle logic in `components.js`
- include shared script on all prototype pages
- add toggle button markup across pages
- drop old inline theme switchers

## Testing
- `npm install`
- `npm run build:manifest`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6889988fd3588325a83411ae675c5990