### PR TITLE
Add DOM outlines for prototype pages

### DIFF
--- a/research/analysis/maps/create-account.dom.md
+++ b/research/analysis/maps/create-account.dom.md
@@ -1,0 +1,18 @@
+# DOM Map: create-account.html
+
+- body.loginBackground
+  - header.login-header
+    - div.logo-wrapper
+      - img.aspen-logo
+    - div (theme toggle)
+      - button#themeToggle.theme-toggle
+  - main.login-main
+    - div.logonDetailContainer
+      - h2.login-title
+      - p
+      - a[href="/index.html"]
+  - footer.login-footer
+    - div.footer-left
+
+## 🧩 Component Candidates
+- login-form

--- a/research/analysis/maps/detail.dom.md
+++ b/research/analysis/maps/detail.dom.md
@@ -1,0 +1,38 @@
+# DOM Map: detail.html
+
+- body
+  - div.layout-wrapper
+    - nav.top-nav
+    - div (theme toggle)
+    - div.layout-container
+      - aside.sidebar
+        - nav.sidebar-nav
+          - ul
+            - li > a
+      - main.main-panel
+        - nav.student-tabs
+        - form.detail-form
+          - section.form-section (Student Info)
+            - h2.form-section__title
+            - div.detail-form__row
+              - label[for="studentName"]
+              - input#studentName
+              - span.error-message
+            - div.detail-form__row
+              - label[for="grade"]
+              - select#grade
+            - div.detail-form__row
+              - label[for="studentId"]
+              - input#studentId
+          - section.form-section (Health)
+            - h2.form-section__title
+            - div.detail-form__row
+              - label[for="notes"]
+              - textarea#notes
+          - div.form-actions.form-actions--sticky
+            - button.button (Save)
+            - button.button (Cancel)
+
+## 🧩 Component Candidates
+- detail-form
+- student-tabs

--- a/research/analysis/maps/exam-form.dom.md
+++ b/research/analysis/maps/exam-form.dom.md
@@ -1,0 +1,17 @@
+# DOM Map: exam-form.html
+
+- body
+  - div (theme toggle)
+    - button#themeToggle.theme-toggle
+  - form.exam-form
+    - div.exam-form__row (Exam Date)
+      - label[for="examDate"]
+      - input#examDate
+    - div.exam-form__row (Notes)
+      - label[for="examNotes"]
+      - textarea#examNotes
+    - div.form-actions
+      - button.button
+
+## 🧩 Component Candidates
+- exam-form

--- a/research/analysis/maps/index.dom.md
+++ b/research/analysis/maps/index.dom.md
@@ -1,0 +1,30 @@
+# DOM Map: index.html
+
+- body.loginBackground
+  - div.wrapper
+    - div.main-content
+      - noscript
+        - div.noscript-warning
+      - header.login-header
+        - div.logo-wrapper
+          - img.aspen-logo
+        - div (theme toggle)
+          - button#themeToggle.theme-toggle
+      - main.login-main
+        - form.logonDetailContainer[name="logonForm"]
+          - input[type=hidden] (token, userEvent, userParam, etc.)
+          - h2.login-title
+          - label + input#username.logonInput
+          - label + input#password.logonInput
+          - label + select#languageSelect.logonSelect
+          - div.login-links (help & reset links)
+          - button#logonButton.button
+          - div.login-legal
+            - iframe
+      - footer.login-footer.footer
+        - div.footer-left
+        - div.footer-right
+
+## 🧩 Component Candidates
+- login-form
+- login-footer

--- a/research/analysis/maps/list.dom.md
+++ b/research/analysis/maps/list.dom.md
@@ -1,0 +1,21 @@
+# DOM Map: list.html
+
+- body
+  - div.layout-wrapper
+    - nav.top-nav
+    - div (theme toggle)
+    - div.layout-container
+      - aside.sidebar
+      - main.main-panel
+        - div.button-menu
+        - div.find-bar
+          - div.find-bar__search
+          - div.find-bar__filters
+          - div.find-bar__bulk-actions
+        - div.table-wrapper
+          - table.table
+        - div.pagination
+
+## 🧩 Component Candidates
+- data-table
+- find-bar

--- a/research/analysis/maps/login-form.dom.md
+++ b/research/analysis/maps/login-form.dom.md
@@ -1,0 +1,17 @@
+# DOM Map: login-form.html
+
+- body
+  - div (theme toggle)
+    - button#themeToggle.theme-toggle
+  - form.login-form
+    - div.login-form__field (User ID)
+      - label[for="loginUsername"]
+      - input#loginUsername
+    - div.login-form__field (Password)
+      - label[for="loginPassword"]
+      - input#loginPassword
+    - div.login-form__actions
+      - button.button
+
+## 🧩 Component Candidates
+- login-form

--- a/research/analysis/maps/reset-password.dom.md
+++ b/research/analysis/maps/reset-password.dom.md
@@ -1,0 +1,18 @@
+# DOM Map: reset-password.html
+
+- body.loginBackground
+  - header.login-header
+    - div.logo-wrapper
+      - img.aspen-logo
+    - div (theme toggle)
+      - button#themeToggle.theme-toggle
+  - main.login-main
+    - div.logonDetailContainer
+      - h2.login-title
+      - p
+      - a[href="/index.html"]
+  - footer.login-footer
+    - div.footer-left
+
+## 🧩 Component Candidates
+- login-form


### PR DESCRIPTION
## Summary
- map login-related pages like `create-account.html` and `reset-password.html`
- capture main structure for index page and list/detail views
- outline components for standalone form examples

## Testing
- `npm install`
- `npm run build:manifest`


------
https://chatgpt.com/codex/tasks/task_e_6889ad7d82548325aca3a733f792d9d9