### PR TITLE
Fix login header and footer style

### DIFF
--- a/prototype/pages/index.html
+++ b/prototype/pages/index.html
@@ -23,7 +23,7 @@
         <div class="noscript-warning">JavaScript is required to use Aspen. Please enable JavaScript.</div>
       </noscript>
 
-      <header class="login-header login-header--plain">
+      <header class="login-header">
         <div class="logo-wrapper">
           <img src="../../images/aspen-header-logo.png" alt="CPS Aspen Header Logo" class="aspen-logo">
         </div>
@@ -75,7 +75,7 @@
     </form>
   </main>
 
-      <footer class="footer login-footer login-footer--plain">
+      <footer class="footer login-footer">
         <div class="footer-left">
           &copy; 2025 Follett School Solutions, LLC. All rights reserved.
         </div>

--- a/prototype/styles/common-mo.css
+++ b/prototype/styles/common-mo.css
@@ -232,6 +232,8 @@ a:hover {
 }
 .main-content {
   flex: 1;
+  display: flex;
+  flex-direction: column;
 }
 .footer {
   background-color: var(--footer-bg);

--- a/prototype/styles/themes.css
+++ b/prototype/styles/themes.css
@@ -44,3 +44,16 @@
   --status-warn: #e09533;
   --status-na: #8a8a8a;
 }
+
+[data-theme="light"] {
+  --bg-default: #FDF6EC;
+  --bg-form: #ffffff;
+  --text-color: #333333;
+  --color-primary: var(--color-school);
+  --color-primary-dark: #357ABD;
+  --footer-bg: rgba(74, 144, 226, 0.9);
+  --header-bg: rgba(74, 144, 226, 0.91);
+  --status-ok: var(--accent-mint);
+  --status-warn: #c26100;
+  --status-na: #6b6b6b;
+}


### PR DESCRIPTION
## Summary
- restore colored header and footer
- force light theme when `data-theme="light"`
- make main content stretch to keep footer at bottom

## Testing
- `npm install`
- `npm run build:manifest`


------
https://chatgpt.com/codex/tasks/task_e_6889b9e84b108325966843a48ed8f3cf