### PR TITLE
Add responsive grid and search widget

### DIFF
--- a/prototype/pages/home.html
+++ b/prototype/pages/home.html
@@ -22,13 +22,13 @@
       <button type="button" id="themeToggle" class="theme-toggle" aria-label="Toggle color scheme" aria-pressed="false">Toggle Theme</button>
     </div>
 
-    <div class="layout-container">
-      <aside class="sidebar">
+    <div class="layout-grid">
+      <aside class="layout-grid__sidebar sidebar">
         <!-- placeholder sidebar -->
         <p>Sidebar navigation</p>
       </aside>
 
-      <main class="main-panel">
+      <main class="layout-grid__main main-panel">
         <div class="main-grid">
           <div class="main-grid__left">
             <section class="widget mb-4">

--- a/prototype/scripts/components.js
+++ b/prototype/scripts/components.js
@@ -65,10 +65,25 @@ export function initThemeToggle() {
   setState(document.documentElement.dataset.theme || 'light');
 }
 
+export function initSearchBars() {
+  document.querySelectorAll('.find-bar__search input[type="text"]').forEach(input => {
+    const table = input.closest('main')?.querySelector('table');
+    if (!table) return;
+    input.addEventListener('input', () => {
+      const query = input.value.toLowerCase();
+      table.querySelectorAll('tbody tr').forEach(row => {
+        const text = row.textContent.toLowerCase();
+        row.hidden = !text.includes(query);
+      });
+    });
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   initComponents();
   initTabs();
   initStickyActions();
   initModals();
   initThemeToggle();
+  initSearchBars();
 });

--- a/prototype/styles/layout.css
+++ b/prototype/styles/layout.css
@@ -23,13 +23,23 @@
   min-height: 0; /* avoid overflow when sidebar is fixed */
 }
 
-.sidebar {
+/* grid-based alternative layout */
+.layout-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: auto 1fr;
+  min-height: 100vh;
+}
+
+.sidebar,
+.layout-grid__sidebar {
   flex: 1 0 100%;
   background-color: var(--bg-form);
   padding: 1rem;
 }
 
-.main-panel {
+.main-panel,
+.layout-grid__main {
   flex: 1 1 auto;
   padding: 1rem;
 }
@@ -39,6 +49,9 @@
   }
   .sidebar {
     flex: 0 0 16rem;
+  }
+  .layout-grid {
+    grid-template-columns: 16rem 1fr;
   }
 }
 

--- a/prototype/styles/legacy-map.css
+++ b/prototype/styles/legacy-map.css
@@ -13,6 +13,10 @@
   --legacy-planner: #669900;
   --legacy-quest: #193366;
   --legacy-pd: #1966b2;
+  --legacy-repo-height: 390px;
+  --legacy-h1-size: 100%;
+  --legacy-disabled-opacity: 0.33;
+  --legacy-accordion-bg: #ffffcc;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -46,3 +50,11 @@
 .menuItemHighlight { background-color: var(--legacy-menu-highlight); }
 
 .listCellLastSelectionHighlight { background-color: var(--legacy-highlight) !important; }
+
+/* mappings for classes with conflicts across legacy stylesheets */
+.repositoryListClass { height: var(--legacy-repo-height); }
+.reset_style_h1,
+.reset_style_h1_top { font-size: var(--legacy-h1-size); margin: 0; }
+.ui-accordion-header { background-color: var(--legacy-accordion-bg); }
+.disabled { opacity: var(--legacy-disabled-opacity); }
+.reposMenuLeft { float: left; }


### PR DESCRIPTION
## Summary
- implement BEM-friendly grid classes in `layout.css`
- map legacy classes to CSS variables in `legacy-map.css`
- add search filtering widget in `components.js`
- convert home page to use the new grid block

## Testing
- `npm run build:manifest`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6889cb2889f88325891e353dff396b7c