### PR TITLE
Expand prototype forms

### DIFF
--- a/prototype/pages/detail.html
+++ b/prototype/pages/detail.html
@@ -14,7 +14,16 @@
   <link rel="stylesheet" href="../styles/themes.css">
 </head>
 <body>
-  <div class="layout-wrapper">
+  <form name="personAddressDetailForm" method="post" action="/aspen/personAddressDetail.do">
+    <input type="hidden" name="org.apache.struts.taglib.html.TOKEN" value="af769c85d55ffa9d66033b7705551f45">
+    <input type="hidden" id="userEvent" name="userEvent" value="930">
+    <input type="hidden" id="userParam" name="userParam" value="">
+    <input type="hidden" id="operationId" name="operationId" value="">
+    <input type="hidden" id="deploymentId" name="deploymentId" value="aspen">
+    <input type="hidden" id="scrollX" name="scrollX" value="0">
+    <input type="hidden" id="scrollY" name="scrollY" value="0">
+    <input type="hidden" id="formFocusField" name="formFocusField" value="">
+    <div class="layout-wrapper">
     <nav class="top-nav">
       <div>Chicago Public Schools</div>
       <div>User: Jane Admin</div>
@@ -76,8 +85,8 @@
         </form>
       </main>
     </div>
-  </div>
-
+    </div>
+  </form>
   <script type="module" src="../scripts/components.js"></script>
 </body>
 </html>

--- a/prototype/pages/exam-form.html
+++ b/prototype/pages/exam-form.html
@@ -13,7 +13,15 @@
   <div style="display: flex; justify-content: center; margin-bottom: 1rem;">
     <button type="button" id="themeToggle" class="theme-toggle" aria-label="Toggle color scheme" aria-pressed="false">Toggle Theme</button>
   </div>
-  <form class="exam-form">
+  <form name="healthExamForm" method="post" action="/aspen/healthExamForm.do" class="exam-form">
+    <input type="hidden" name="org.apache.struts.taglib.html.TOKEN" value="af769c85d55ffa9d66033b7705551f45">
+    <input type="hidden" id="userEvent" name="userEvent" value="0">
+    <input type="hidden" id="userParam" name="userParam" value="">
+    <input type="hidden" id="operationId" name="operationId" value="">
+    <input type="hidden" id="deploymentId" name="deploymentId" value="aspen">
+    <input type="hidden" id="scrollX" name="scrollX" value="0">
+    <input type="hidden" id="scrollY" name="scrollY" value="0">
+    <input type="hidden" id="formFocusField" name="formFocusField" value="">
     <div class="exam-form__row">
       <label for="examDate">Exam Date</label>
       <input type="date" id="examDate" required>

--- a/prototype/pages/home.html
+++ b/prototype/pages/home.html
@@ -13,7 +13,16 @@
   <link rel="stylesheet" href="../styles/themes.css">
 </head>
 <body>
-  <div class="layout-wrapper">
+  <form name="authenticatedActionForm" method="post" action="/aspen/home.do">
+    <input type="hidden" name="org.apache.struts.taglib.html.TOKEN" value="af769c85d55ffa9d66033b7705551f45">
+    <input type="hidden" id="userEvent" name="userEvent" value="0">
+    <input type="hidden" id="userParam" name="userParam" value="">
+    <input type="hidden" id="operationId" name="operationId" value="">
+    <input type="hidden" id="deploymentId" name="deploymentId" value="aspen">
+    <input type="hidden" id="scrollX" name="scrollX" value="0">
+    <input type="hidden" id="scrollY" name="scrollY" value="0">
+    <input type="hidden" id="formFocusField" name="formFocusField" value="">
+    <div class="layout-wrapper">
     <nav class="top-nav">
       <div>Chicago Public Schools</div>
       <div>User: Jane Admin</div>
@@ -92,8 +101,8 @@
         </div>
       </main>
     </div>
-  </div>
-
+    </div>
+  </form>
   <script type="module" src="../scripts/components.js"></script>
 </body>
 </html>

--- a/prototype/pages/immunizations.html
+++ b/prototype/pages/immunizations.html
@@ -13,7 +13,16 @@
   <link rel="stylesheet" href="../styles/themes.css">
 </head>
 <body>
-  <div class="layout-wrapper">
+  <form name="immunizationInputForm" method="post" action="/aspen/immunizationForm.do">
+    <input type="hidden" name="org.apache.struts.taglib.html.TOKEN" value="af769c85d55ffa9d66033b7705551f45">
+    <input type="hidden" id="userEvent" name="userEvent" value="0">
+    <input type="hidden" id="userParam" name="userParam" value="">
+    <input type="hidden" id="operationId" name="operationId" value="">
+    <input type="hidden" id="deploymentId" name="deploymentId" value="aspen">
+    <input type="hidden" id="scrollX" name="scrollX" value="0">
+    <input type="hidden" id="scrollY" name="scrollY" value="0">
+    <input type="hidden" id="formFocusField" name="formFocusField" value="">
+    <div class="layout-wrapper">
     <nav class="top-nav">
       <div>Chicago Public Schools</div>
       <div>User: Jane Admin</div>
@@ -65,8 +74,8 @@
         </div>
       </main>
     </div>
-  </div>
-
+    </div>
+  </form>
   <script type="module" src="../scripts/components.js"></script>
 </body>
 </html>

--- a/prototype/pages/index.html
+++ b/prototype/pages/index.html
@@ -27,6 +27,9 @@
         <div class="logo-wrapper">
           <img src="../../images/aspen-header-logo.png" alt="CPS Aspen Header Logo" class="aspen-logo">
         </div>
+        <div style="display: flex; justify-content: center;">
+          <button type="button" id="themeToggle" class="theme-toggle" aria-label="Toggle color scheme" aria-pressed="false">Toggle Theme</button>
+        </div>
       </header>
 
       <main class="login-main">

--- a/prototype/pages/list.html
+++ b/prototype/pages/list.html
@@ -14,7 +14,16 @@
   <link rel="stylesheet" href="../styles/themes.css">
 </head>
 <body>
-  <div class="layout-wrapper">
+  <form name="contextListForm" method="post" action="/aspen/studentContextList.do">
+    <input type="hidden" name="org.apache.struts.taglib.html.TOKEN" value="af769c85d55ffa9d66033b7705551f45">
+    <input type="hidden" id="userEvent" name="userEvent" value="0">
+    <input type="hidden" id="userParam" name="userParam" value="">
+    <input type="hidden" id="operationId" name="operationId" value="">
+    <input type="hidden" id="deploymentId" name="deploymentId" value="aspen">
+    <input type="hidden" id="scrollX" name="scrollX" value="0">
+    <input type="hidden" id="scrollY" name="scrollY" value="0">
+    <input type="hidden" id="formFocusField" name="formFocusField" value="">
+    <div class="layout-wrapper">
     <nav class="top-nav">
       <div>Chicago Public Schools</div>
       <div>User: Jane Admin</div>
@@ -81,8 +90,8 @@
         <div class="pagination mt-2">Page 1 of 4</div>
       </main>
     </div>
-  </div>
-
+    </div>
+  </form>
   <script type="module" src="../scripts/components.js"></script>
 </body>
 </html>

--- a/prototype/pages/membership.html
+++ b/prototype/pages/membership.html
@@ -13,7 +13,16 @@
   <link rel="stylesheet" href="../styles/themes.css">
 </head>
 <body>
-  <div class="layout-wrapper">
+  <form name="contextListForm" method="post" action="/aspen/studentEnrollmentList.do">
+    <input type="hidden" name="org.apache.struts.taglib.html.TOKEN" value="af769c85d55ffa9d66033b7705551f45">
+    <input type="hidden" id="userEvent" name="userEvent" value="0">
+    <input type="hidden" id="userParam" name="userParam" value="">
+    <input type="hidden" id="operationId" name="operationId" value="">
+    <input type="hidden" id="deploymentId" name="deploymentId" value="aspen">
+    <input type="hidden" id="scrollX" name="scrollX" value="0">
+    <input type="hidden" id="scrollY" name="scrollY" value="0">
+    <input type="hidden" id="formFocusField" name="formFocusField" value="">
+    <div class="layout-wrapper">
     <nav class="top-nav">
       <div>Chicago Public Schools</div>
       <div>User: Jane Admin</div>
@@ -65,8 +74,8 @@
         </div>
       </main>
     </div>
-  </div>
-
+    </div>
+  </form>
   <script type="module" src="../scripts/components.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add theme toggle to login page
- wrap prototype pages in backend-compatible forms

## Testing
- `npm run build:manifest`

------
https://chatgpt.com/codex/tasks/task_e_6889d401ee94832583c36c20d8424199